### PR TITLE
saving output audio file in the experiment path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+# Mac file
+.DS_store

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -90,8 +90,6 @@ class audio_low_latency_record_start(item):
         extension = 'wav'
         # Make output location relative to location of experiment
         rel_loc = os.path.normpath(self.get("filename"))
-        if re.findall(r'[^A-Za-z0-9_\-\\\[\]]',rel_loc):
-           raise osexception("filename not valid. Use only [A-Za-z0-9] and _-")
         if self.experiment.experiment_path is None:
             raise osexception("Path to experiment not found. Please save the experiment to a file first")
 

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -98,7 +98,7 @@ class audio_low_latency_record_start(item):
         output_file = os.path.normpath(os.path.join(self.experiment.experiment_path, rel_loc))
         # Check for a subfolder (when it is specified) that it exists and if not, create it
         if os.path.exists(os.path.dirname(output_file)):
-            if self.file_exists_action == u'yes':
+            if self.var.file_exists_action == u'yes':
                 # Search for underscore/number suffixes
                 output_file = self._generate_suffix(output_file)
         else:

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -28,6 +28,7 @@ from libopensesame.exceptions import osexception
 from openexp.keyboard import keyboard
 import threading
 import wave
+import numpy
 
 VERSION = u'8.2.0'
 
@@ -288,6 +289,7 @@ class audio_low_latency_record_start(item):
             l, data = stream.read()
         else:
             data = stream.read(chunk)
+            data = numpy.frombuffer(data[0])
 
         # save data to file/ram
         if self.ram_cache == u'yes':

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -89,7 +89,7 @@ class audio_low_latency_record_start(item):
     def _build_output_file(self):
         extension = 'wav'
         # Make output location relative to location of experiment
-        rel_loc = os.path.normpath(self.get("output_file"))
+        rel_loc = os.path.normpath(self.get("filename"))
         if re.findall(r'[^A-Za-z0-9_\-\\]',rel_loc):
            raise osexception("filename not valid. Use only [A-Za-z0-9] and _-")
         if self.experiment.experiment_path is None:

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -90,7 +90,7 @@ class audio_low_latency_record_start(item):
         extension = 'wav'
         # Make output location relative to location of experiment
         rel_loc = os.path.normpath(self.get("filename"))
-        if re.findall(r'[^A-Za-z0-9_\-\\]',rel_loc):
+        if re.findall(r'[^A-Za-z0-9_\-\\\[\]]',rel_loc):
            raise osexception("filename not valid. Use only [A-Za-z0-9] and _-")
         if self.experiment.experiment_path is None:
             raise osexception("Path to experiment not found. Please save the experiment to a file first")

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -92,8 +92,7 @@ class audio_low_latency_record_start(item):
         rel_loc = os.path.normpath(self.get("filename"))
         if self.experiment.experiment_path is None:
             raise osexception("Path to experiment not found. Please save the experiment to a file first")
-
-        output_file = os.path.normpath(os.path.join(self.experiment.experiment_path, rel_loc))
+        output_file = os.path.normpath(os.path.join(self.experiment.experiment_path, rel_loc)) + '.wav'
         # Check for a subfolder (when it is specified) that it exists and if not, create it
         if os.path.exists(os.path.dirname(output_file)):
             if self.file_exists_action == u'yes':
@@ -105,7 +104,7 @@ class audio_low_latency_record_start(item):
                     os.makedirs(os.path.dirname(output_file))
                 except Exception as e:
                     raise osexception("Error creating sound file: " + str(e))
-        return output_file + '.wav'
+        return output_file
 
     def init_var(self):
 

--- a/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
+++ b/opensesame_plugins/audio_low_latency_record_start/audio_low_latency_record_start.py
@@ -55,7 +55,7 @@ class audio_low_latency_record_start(item):
 
         # Set default experimental variables and values
         self.var.filename = u''
-        self.var.file_exists_action == u'no'
+        self.var.file_exists_action = u'no'
         self.var.duration = u'infinite'
         self.var.delay_start = 0
         self.var.delay_stop = 0
@@ -98,7 +98,7 @@ class audio_low_latency_record_start(item):
         output_file = os.path.normpath(os.path.join(self.experiment.experiment_path, rel_loc))
         # Check for a subfolder (when it is specified) that it exists and if not, create it
         if os.path.exists(os.path.dirname(output_file)):
-            if self.var.file_exists_action == u'yes':
+            if self.file_exists_action == u'yes':
                 # Search for underscore/number suffixes
                 output_file = self._generate_suffix(output_file)
         else:

--- a/opensesame_plugins/audio_low_latency_record_start/info.yaml
+++ b/opensesame_plugins/audio_low_latency_record_start/info.yaml
@@ -12,7 +12,7 @@ controls:
     type: "line_edit"
     var: "filename"
 -
-    label: "Append suffix"
+    label: "Do not overwrite existing files, automatically append suffix"
     name: "checkbox_file_exists_action"
     tooltip: "If file exists append suffix to filename?"
     type: "checkbox"

--- a/opensesame_plugins/audio_low_latency_record_start/info.yaml
+++ b/opensesame_plugins/audio_low_latency_record_start/info.yaml
@@ -7,10 +7,16 @@ date: "2022"
 controls:
 -
     label: "Audio Filename"
-    name: "filepool_filename"
-    tooltip: "Give filename"
-    type: "filepool"
+    name: "line_edit_filename"
+    tooltip: "Give output filename without extension"
+    type: "line_edit"
     var: "filename"
+-
+    label: "Append suffix"
+    name: "checkbox_file_exists_action"
+    tooltip: "If file exists append suffix to filename?"
+    type: "checkbox"
+    var: "file_exists_action"
 -
     label: "Duration (ms)"
     info: "Expecting a value in ms or a string 'infinite'"


### PR DESCRIPTION
Hi.
As said in title, the audio ouput is now saved in the experiment path.
no extension is needed, it will be added automatically, and the filename is checked to be valid and can use opensesame parameters.

I added an option to add a suffix to the filename if audio file already exist.

